### PR TITLE
working ssh!

### DIFF
--- a/src/login.rs
+++ b/src/login.rs
@@ -2,13 +2,6 @@ use std::io::Write;
 
 use tokio::io::AsyncWriteExt;
 
-#[derive(clap::Parser)]
-pub(crate) struct LoginArguments {
-    /// root URL of the gallium API server
-    #[arg(long, default_value = "https://api-staging.gallium.cloud/api")]
-    api_root_url: String,
-}
-
 #[derive(serde::Deserialize, Debug)]
 struct LoginResponse {
     #[serde(rename = "mfaRequired")]
@@ -82,7 +75,7 @@ fn prompt_and_read_line(prompt: &str) -> String {
     buffer.trim().into()
 }
 
-pub(crate) async fn login(args: LoginArguments) {
+pub(crate) async fn login(args: &crate::GlobalArguments) {
     let email = prompt_and_read_line("email");
     let password = prompt_and_read_line("password");
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -9,7 +9,7 @@ pub(crate) struct ProxyArguments {
     ws_url: String,
 }
 
-pub(crate) async fn proxy(args: ProxyArguments) {
+pub(crate) async fn proxy(args: &ProxyArguments) {
     let request = url::Url::parse(&args.ws_url)
         .expect("valid url")
         .into_client_request()
@@ -42,10 +42,7 @@ pub(crate) async fn proxy(args: ProxyArguments) {
                 .write_all(&msg.into_data())
                 .await
                 .expect("write to stdout");
-            stdout
-                .flush()
-                .await
-                .expect("flush stdout");
+            stdout.flush().await.expect("flush stdout");
         }
     });
 

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,0 +1,72 @@
+use std::os::unix::process::CommandExt;
+
+#[derive(clap::Parser)]
+pub(crate) struct SshArguments {
+    destination: String,
+
+    #[arg(last = true)]
+    additional_ssh_args: Vec<String>,
+}
+
+pub(crate) async fn ssh(gargs: &crate::GlobalArguments, args: &SshArguments) {
+    let host = match args.destination.split_once('@') {
+        Some((_, host)) => host,
+        None => args.destination.as_str(),
+    };
+
+    let access_token = crate::login::get_access_token(&gargs.api_root_url)
+        .await
+        .expect("access token");
+
+    let ws_url = get_ws_url(
+        &gargs.api_root_url,
+        &access_token,
+        &host,
+        // TODO 2023.09.06: should this be possible to override? If so, what's the syntax?
+        "22",
+    )
+    .await
+    .expect("ws url");
+
+    std::process::Command::new("ssh")
+        .args([
+            String::from("-o"),
+            format!(
+                "ProxyCommand={} proxy {}",
+                std::env::current_exe().unwrap().display(),
+                ws_url
+            ),
+        ])
+        .args(args.additional_ssh_args.clone())
+        .arg(args.destination.clone())
+        .exec();
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct WsResponse {
+    url: String,
+}
+
+async fn get_ws_url(
+    api_root_url: impl ToString,
+    access_token: impl ToString,
+    host: impl ToString,
+    port: impl ToString,
+) -> anyhow::Result<String> {
+    let response = reqwest::Client::new()
+        .get(format!("{}/ws/ws_for_vm_service", api_root_url.to_string()))
+        .query(&[("host", host.to_string())])
+        .query(&[("port", port.to_string())])
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", access_token.to_string()),
+        )
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        anyhow::bail!(response.text().await.unwrap());
+    }
+
+    Ok(response.json::<WsResponse>().await?.url)
+}


### PR DESCRIPTION
This seems to be working!

```
$ cargo run -- ssh root@webserver
   Compiling gallium-cli v0.1.0 (/Users/dlowe/gallium-cloud/gallium-cli)
    Finished dev [unoptimized + debuginfo] target(s) in 2.18s
     Running `target/debug/gallium-cli ssh 'root@webserver'`
Linux webserver 6.1.0-9-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.27-1 (2023-05-08) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Wed Sep  6 21:49:02 2023 from 192.168.122.1
root@webserver:~#
```

Questions:
 * should the port be overrideable? It's currently hard-coded as 22.
 * does this need to work on windows? I'm using `exec()` which is unix-specific; switching to `spawn()` + `wait()` shouldn't be a problem, but it's not quite as clean if we're unix-only.